### PR TITLE
Fix broken URLs of example datasets

### DIFF
--- a/pandas_alive/_base_chart.py
+++ b/pandas_alive/_base_chart.py
@@ -158,7 +158,7 @@ class _BaseChart:
                 )
             if self.writer not in manimation.writers.list():
                 raise RuntimeError(
-                    f"Ensure that a matplotlib writer library is installed, list of available writer librarys {manimation.writers.list()}, see https://github.com/JackMcKew/pandas_alive/blob/master/README.md#requirements for more details"
+                    f"Ensure that a matplotlib writer library is installed, list of available writer librarys {manimation.writers.list()}, see https://github.com/JackMcKew/pandas_alive/blob/main/README.md#requirements for more details"
                 )
 
     def get_period_label(
@@ -595,7 +595,7 @@ class _BaseChart:
 
         except TypeError as e:
             raise RuntimeError(
-                "Ensure that a matplotlib writer library is installed, see https://github.com/JackMcKew/pandas_alive/blob/master/README.md#requirements for more details"
+                "Ensure that a matplotlib writer library is installed, see https://github.com/JackMcKew/pandas_alive/blob/main/README.md#requirements for more details"
             )
 
     # def encode_html5_video(self,anim):

--- a/pandas_alive/base.py
+++ b/pandas_alive/base.py
@@ -26,7 +26,7 @@ def load_dataset(name: str = "covid19") -> pd.DataFrame:
     """
 
     return pd.read_csv(
-        f"https://raw.githubusercontent.com/JackMcKew/pandas_alive/master/data/{name}.csv",
+        f"https://raw.githubusercontent.com/JackMcKew/pandas_alive/main/data/{name}.csv",
         index_col=0,
         parse_dates=[0],
     )


### PR DESCRIPTION
The function `pandas_alive.load_dataset()` returns an HTTP error. It seems the `master` branch has been renamed as the `main` branch. The sample dataset file paths should be updated as well

https://raw.githubusercontent.com/JackMcKew/pandas_alive/main/data/covid19.csv

![](https://i.imgur.com/XGB8iCO.png)